### PR TITLE
Build noop email_validator output

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,9 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.6.* *_cpython
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xylar
+* @pmlandwehr @xylar

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: CC0-1.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/email-validator-feedstock/blob/master/LICENSE.txt)
 
-Summary: A robust email syntax and deliverability validation library for Python 2.x/3.x.
+Summary: A robust email syntax and deliverability validation library for 3.x.
 
 Development: https://github.com/JoshData/python-email-validator
 
@@ -32,6 +32,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-email--validator-green.svg)](https://anaconda.org/conda-forge/email-validator) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/email-validator.svg)](https://anaconda.org/conda-forge/email-validator) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/email-validator.svg)](https://anaconda.org/conda-forge/email-validator) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/email-validator.svg)](https://anaconda.org/conda-forge/email-validator) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-email_validator-green.svg)](https://anaconda.org/conda-forge/email_validator) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/email_validator.svg)](https://anaconda.org/conda-forge/email_validator) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/email_validator.svg)](https://anaconda.org/conda-forge/email_validator) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/email_validator.svg)](https://anaconda.org/conda-forge/email_validator) |
 
 Installing email-validator
 ==========================
@@ -42,10 +43,10 @@ Installing `email-validator` from the `conda-forge` channel can be achieved by a
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `email-validator` can be installed with:
+Once the `conda-forge` channel has been enabled, `email-validator, email_validator` can be installed with:
 
 ```
-conda install email-validator
+conda install email-validator email_validator
 ```
 
 It is possible to list all of the versions of `email-validator` available on your platform with:
@@ -118,5 +119,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@pmlandwehr](https://github.com/pmlandwehr/)
 * [@xylar](https://github.com/xylar/)
 

--- a/recipe/build_email_validator.sh
+++ b/recipe/build_email_validator.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+${PYTHON} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.1.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-meta
   version: {{ version }}
 
 source:
@@ -10,45 +10,63 @@ source:
   sha256: 01498d84bd576c449e476a49aa70722a9aaf2a3b00957d53ddb2f3bec04b0855
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  entry_points:
-    - email_validator=email_validator:main
-  script: {{ PYTHON }} -m pip install . -vv
 
-requirements:
-  host:
-    - pip
-    - python >=3.5
-  run:
-    - dnspython >=1.15.0
-    - idna >=2.0.0
-    - python >=3.5
+outputs:
+  - name: {{ name|lower }}
+    build:
+      noarch: python
+      entry_points:
+        - email_validator = email_validator:main
+    script: build_email_validator.sh
+    requirements:
+      host:
+        - python >=3.5
+        - pip
+      run:
+        - python >=3.5
+        - idna >=2.0.0
+        - dnspython >=1.15.0
+    test:
+      source_files:
+        - tests
+      requires:
+        - coverage
+        - docutils
+        - flake8
+        - pytest
+        - pytest-cov
+      imports:
+        - email_validator
+      commands:
+        - email_validator --help
+        - pytest --cov=email_validator
 
-test:
-  source_files:
-    - tests
-  requires:
-    - coverage
-    - docutils
-    - flake8
-    - pytest
-    - pytest-cov
-  imports:
-    - email_validator
-  commands:
-    - email_validator --help
-    - pytest --cov=email_validator
+  # Provide package with alternative name for backward compatibility
+  - name: email_validator
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage('email-validator', max_pin="x.x.x") }}
+    test:
+      imports:
+        - email_validator
+      commands:
+        - email_validator --help
 
 about:
   home: https://github.com/JoshData/python-email-validator
   license: CC0-1.0
   license_family: CC
   license_file: LICENSE
-  summary: A robust email syntax and deliverability validation library for Python 2.x/3.x.
+  summary: A robust email syntax and deliverability validation library for 3.x.
   doc_url: https://github.com/JoshData/python-email-validator
   dev_url: https://github.com/JoshData/python-email-validator
 
 extra:
+  feedstock-name: email-validator
   recipe-maintainers:
     - xylar
+    - pmlandwehr


### PR DESCRIPTION
There has been confusion about `email_validator` (underscore) and `email-validator` (hyphen), and I made this redundant feedstock for the latter by mistake.  This merge makes `email_validator` a second output of this feedstock that just depends on the same version of `email-validator`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #3 